### PR TITLE
add width to card title

### DIFF
--- a/web/site/components/Sbc/ProductCard.vue
+++ b/web/site/components/Sbc/ProductCard.vue
@@ -21,6 +21,7 @@ async function goToProduct () {
       <a
         :href="localePath(`/products/${directory}/overview`)"
         class="text-white focus:outline-none"
+        :class="{ 'w-3/4': badge }"
       >
         {{ name }}
       </a>


### PR DESCRIPTION
issue: #82 

- add width to card title string if there is a badge rendered to prevent title/badge overlap